### PR TITLE
Make .alert position absolute

### DIFF
--- a/app/assets/stylesheets/components/_alert.scss
+++ b/app/assets/stylesheets/components/_alert.scss
@@ -2,7 +2,7 @@
   display: flex;
   justify-content: space-around;
   align-items: center;
-  position: fixed;
+  position: absolute;
   bottom: 16px;
   z-index: 1000;
   width: 100%;

--- a/app/assets/stylesheets/components/_navbar.scss
+++ b/app/assets/stylesheets/components/_navbar.scss
@@ -73,6 +73,9 @@
 #hamburger-menu {
   font-size: 1.25em;
 }
+#hamburger-menu:hover, :active, :focus {
+  outline: none;
+}
 
 .nav-item a {
   color: white !important;


### PR DESCRIPTION
to get rid of the white space between the alert bar and the navbar